### PR TITLE
update lodash and fix model stream test

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
     "node": ">= v0.8.x"
   },
   "dependencies": {
-    "safe": "~0.3.0",
-    "lodash": "~3.10.x",
+    "lodash": "~4.17.11",
     "mkdirp": "~0.5.0",
-    "tingodb": "~0.4.1",
-    "mongodb": "1.4.x"
+    "mongodb": "1.4.x",
+    "safe": "~0.3.0",
+    "tingodb": "~0.4.1"
   },
   "scripts": {
-		"test":"mocha ./test/*.test.js"
+    "test": "mocha ./test/*.test.js"
   },
   "devDependencies": {
-      "mocha":"1.21.x",
-      "mongoose": "3.6.x"
+    "mocha": "1.21.x",
+    "mongoose": "3.6.x"
   }
 }

--- a/test/model.stream.test.js
+++ b/test/model.stream.test.js
@@ -239,7 +239,7 @@ describe('query stream:', function(){
       assert.ok(/Adrian/.test(contents));
       assert.ok(/Aditya/.test(contents));
       assert.ok(/Agustin/.test(contents));
-      fs.unlink(filename);
+      fs.unlinkSync(filename);
       done();
     }
   })


### PR DESCRIPTION
Lodash needed to be updated as the currently used version is [vulnerable to prototype pollution](https://app.snyk.io/vuln/SNYK-JS-LODASH-73638.).

`fs.unlink()` expects a second arg which is a callback so I switched to using the sync version as per https://github.com/gruntjs/grunt-contrib-jasmine/issues/266#issue-317802730.